### PR TITLE
Docker compose fix

### DIFF
--- a/autostart_hummingbot_compose/docker-compose.yml
+++ b/autostart_hummingbot_compose/docker-compose.yml
@@ -11,10 +11,10 @@ services:
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"
       - "./hummingbot_files/certs:/home/hummingbot/certs"
-#    environment:
-#      - CONFIG_PASSWORD=[password]
-#      - CONFIG_FILE_NAME=simple_pmm_example.py
-#      - CONFIG_FILE_NAME=conf_pure_mm_1.yml
+    # environment:
+    #   - CONFIG_PASSWORD=[password]
+    #   - CONFIG_FILE_NAME=simple_pmm_example.py
+    #   - CONFIG_FILE_NAME=conf_pure_mm_1.yml
     logging:
       driver: "json-file"
       options:

--- a/autostart_hummingbot_compose/docker-compose.yml
+++ b/autostart_hummingbot_compose/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host

--- a/hummingbot_gateway_broker_compose/docker-compose.yml
+++ b/hummingbot_gateway_broker_compose/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   hummingbot:
     container_name: "hummingbot"
     image: hummingbot/hummingbot:latest
-    # image: hummingbot/hummingbot:latest-arm
     volumes:
       - "./hummingbot_files/conf:/conf"
       - "./hummingbot_files/conf/connectors:/conf/connectors"
@@ -26,7 +25,6 @@ services:
   gateway:
     container_name: "gateway"
     image: hummingbot/gateway:latest
-    # image: hummingbot/gateway:latest-arm
     ports:
       - "15888:15888"
       - "8080:8080"

--- a/hummingbot_gateway_broker_compose/docker-compose.yml
+++ b/hummingbot_gateway_broker_compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host

--- a/hummingbot_gateway_compose/docker-compose.yml
+++ b/hummingbot_gateway_compose/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"
       - "./hummingbot_files/certs:/home/hummingbot/certs"
+    # environment:
+    #   - CONFIG_PASSWORD=[password]      
     logging:
       driver: "json-file"
       options:

--- a/hummingbot_gateway_compose/docker-compose.yml
+++ b/hummingbot_gateway_compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host

--- a/multiple_hummingbot_gateway_compose/docker-compose.yml
+++ b/multiple_hummingbot_gateway_compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host
@@ -41,7 +41,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: 5
+        max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host

--- a/multiple_hummingbot_gateway_compose/docker-compose.yml
+++ b/multiple_hummingbot_gateway_compose/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"
       - "./hummingbot_files/certs:/home/hummingbot/certs"
+    # environment:
+    #   - CONFIG_PASSWORD=[password]
     logging:
       driver: "json-file"
       options:
@@ -25,6 +27,8 @@ services:
     image: hummingbot/hummingbot:latest
     volumes:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
+      - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
+      - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"

--- a/simple_hummingbot_compose/docker-compose.yml
+++ b/simple_hummingbot_compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host


### PR DESCRIPTION
- modified compose files to make  them consistent with the readme instructions, 
- some compose files were missing the `environment` variable but is mentioned in the readme instructions
- some were missing the volumes for the `conf/connector` and `conf/strategies` folder