### PR TITLE
fix / dont bind scripts folder

### DIFF
--- a/simple_hummingbot_compose/README.md
+++ b/simple_hummingbot_compose/README.md
@@ -48,7 +48,12 @@ Run this command from your root folder to grant read/write permission to the `hu
 sudo chmod -R a+rw ./hummingbot_files
 ```
 
-### 3. Launch Hummingbot
+### 3. Populate scripts folder with examples
+```
+docker cp hummingbot:/home/hummingbot/scripts ./hummingbot_files/scripts
+```
+
+### 4. Launch Hummingbot
 
 Attach to the `hummingbot` instance:
 ```

--- a/simple_hummingbot_compose/docker-compose.yml
+++ b/simple_hummingbot_compose/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
-      - "./hummingbot_files/scripts:/home/hummingbot/scripts"
       - "./hummingbot_files/certs:/home/hummingbot/certs"
     logging:
       driver: "json-file"


### PR DESCRIPTION
This fixes an issue where binding the the local folder to the `scripts` folder in the volume deletes the contents of the `scripts` folder in the volume.

You can test this by running this command with and without binding the folders.
`docker exec -t [container-tag] ls hummingbot/scripts`

Solution: don't bind the folders, and add instructions to tell the user to run a command that copies the scripts to local folder. Ideally, there's a way to automate this in the compose yaml, but I couldn't figure it out.