### PR TITLE
Fix/adding scripts to dashboard example

### DIFF
--- a/hummingbot_with_dashboard/docker-compose.yml
+++ b/hummingbot_with_dashboard/docker-compose.yml
@@ -1,19 +1,21 @@
 version: "3.9"
 services:
-  bot:
+  hummingbot:
     container_name: hummingbot
     image: hummingbot/hummingbot:latest
     volumes:
-      - ./hummingbot_files/conf:/home/hummingbot/conf
-      - ./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors
-      - ./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies
-      - ./hummingbot_files/logs:/home/hummingbot/logs
-      - ./hummingbot_files/data:/home/hummingbot/data
+      - "./hummingbot_files/conf:/home/hummingbot/conf"
+      - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
+      - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/logs:/home/hummingbot/logs"
+      - "./hummingbot_files/data:/home/hummingbot/data"
+      - "./hummingbot_files/scripts:/home/hummingbot/scripts"
+      - "./hummingbot_files/certs:/home/hummingbot/certs"
     logging:
       driver: "json-file"
       options:
           max-size: "10m"
-          max-file: 5
+          max-file: "5"
     tty: true
     stdin_open: true
     network_mode: host

--- a/hummingbot_with_dashboard/docker-compose.yml
+++ b/hummingbot_with_dashboard/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   hummingbot:
-    container_name: hummingbot
+    container_name: bot
     image: hummingbot/hummingbot:latest
     volumes:
       - "./hummingbot_files/conf:/home/hummingbot/conf"

--- a/hummingbot_with_dashboard/docker-compose.yml
+++ b/hummingbot_with_dashboard/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   hummingbot:
-    container_name: bot
+    container_name: hummingbot
     image: hummingbot/hummingbot:latest
     volumes:
       - "./hummingbot_files/conf:/home/hummingbot/conf"


### PR DESCRIPTION
Description: The PR should fix issue: 

previous docker-compose.yml file was not able to add and change existed script (scripts - added to scripts folder - failed to see/start) 
![image](https://github.com/hummingbot/deploy-examples/assets/83953535/bee6b682-eff1-4222-a716-d06be9858f2f)
New scripts not available in the client, old one not saved configuration
![image](https://github.com/hummingbot/deploy-examples/assets/83953535/3f3cd7a5-c141-4370-a94a-93b60018a2ed)

