### PR TITLE
feat / adding "conf/scripts" folder on compose files

### DIFF
--- a/autostart_hummingbot_compose/docker-compose.yml
+++ b/autostart_hummingbot_compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
       - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/home/hummingbot/conf/scripts"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"

--- a/hummingbot_gateway_broker_compose/docker-compose.yml
+++ b/hummingbot_gateway_broker_compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/conf"
       - "./hummingbot_files/conf/connectors:/conf/connectors"
       - "./hummingbot_files/conf/strategies:/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/conf/scripts"
       - "./hummingbot_files/logs:/logs"
       - "./hummingbot_files/data:/data"
       - "./hummingbot_files/scripts:/scripts"

--- a/hummingbot_gateway_compose/docker-compose.yml
+++ b/hummingbot_gateway_compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
       - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/home/hummingbot/conf/scripts"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"

--- a/hummingbot_with_dashboard/docker-compose.yml
+++ b/hummingbot_with_dashboard/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
       - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/home/hummingbot/conf/scripts"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"

--- a/multiple_hummingbot_gateway_compose/docker-compose.yml
+++ b/multiple_hummingbot_gateway_compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
       - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/home/hummingbot/conf/scripts"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"

--- a/simple_hummingbot_compose/docker-compose.yml
+++ b/simple_hummingbot_compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "./hummingbot_files/conf:/home/hummingbot/conf"
       - "./hummingbot_files/conf/connectors:/home/hummingbot/conf/connectors"
       - "./hummingbot_files/conf/strategies:/home/hummingbot/conf/strategies"
+      - "./hummingbot_files/conf/scripts:/home/hummingbot/conf/scripts"
       - "./hummingbot_files/logs:/home/hummingbot/logs"
       - "./hummingbot_files/data:/home/hummingbot/data"
       - "./hummingbot_files/scripts:/home/hummingbot/scripts"


### PR DESCRIPTION
Added "conf/scripts" on compose files below:

- autostart_hummingbot_compose
- hummingbot_gateway_broker_compose
- hummingbot_gateway_compose
- hummingbot_with_dashboard
- multiple_hummingbot_gateway_compose
- simple_hummingbot_compose 